### PR TITLE
Removed rollup es6 build in favor of pure CommonJS modules for fewer complications

### DIFF
--- a/bin/src/aws.js
+++ b/bin/src/aws.js
@@ -1,0 +1,10 @@
+const AWS = require('aws-sdk');
+
+function configureAws(settings) {
+  const credentials = new AWS.SharedIniFileCredentials({profile: settings.profileName});
+  AWS.config.credentials = credentials;
+  AWS.config.region = settings.region;
+  return AWS;
+}
+
+module.exports = configureAws;

--- a/bin/src/constants.js
+++ b/bin/src/constants.js
@@ -5,9 +5,23 @@ const SETTINGS_FILE = '.lambdasyncrc';
 const AWS_USER_DIR = path.join(userHome, '.aws');
 const AWS_CREDENTIALS_PATH = path.join(AWS_USER_DIR, 'credentials');
 const AWS_CONFIG_PATH = path.join(AWS_USER_DIR, 'config');
-const LAMBDASYNC_ROOT = path.join(__dirname);
-const LAMBDASYNC_BIN = path.join(LAMBDASYNC_ROOT, '..', '..', 'node_modules', '.bin');
+const LAMBDASYNC_ROOT = path.join(__dirname, '..', '..');
+const LAMBDASYNC_BIN = path.join(LAMBDASYNC_ROOT, 'node_modules', '.bin');
 const TARGET_ROOT = process.cwd();
+const PROMPT_CONFIRM_OVERWRITE_FUNCTION = {type: 'confirm', name: 'confirm', message: 'Function already exists, overwrite?'};
+const PROMPT_INPUT_PROFILE_NAME = {type: 'input', name: 'profileName', message: 'Profile name', default: 'lambdasync'};
+const PROMPT_INPUT_FUNCTION_NAME = {type: 'input', name: 'lambdaName', message: 'Function name'};
+const PROMPT_INPUT_ACCESS_KEY = {type: 'input', name: 'accessKey', message: 'AWS Access Key'};
+const PROMPT_INPUT_SECRET_KEY = {type: 'input', name: 'secretKey', message: 'AWS Secret Key'};
+const PROMPT_CHOICE_REGION = {type: 'list', name: 'region', message: 'Region', choices: [
+  {name: 'US East (N. Virginia)', value: 'us-east-1'},
+  {name: 'US West (Oregon)', value: 'us-west-2'},
+  {name: 'Asia Pacific (Singapore)', value: 'ap-southeast-1'},
+  {name: 'Asia Pacific (Sydney)', value: 'ap-southeast-2'},
+  {name: 'Asia Pacific (Tokyo)', value: 'ap-northeast-1'},
+  {name: 'EU (Frankfurt)', value: 'eu-central-1'},
+  {name: 'EU (Ireland)', value: 'eu-west-1'}
+]};
 
 module.exports = {
   SETTINGS_FILE,
@@ -16,5 +30,11 @@ module.exports = {
   AWS_CONFIG_PATH,
   LAMBDASYNC_ROOT,
   LAMBDASYNC_BIN,
-  TARGET_ROOT
+  TARGET_ROOT,
+  PROMPT_CONFIRM_OVERWRITE_FUNCTION,
+  PROMPT_INPUT_PROFILE_NAME,
+  PROMPT_INPUT_FUNCTION_NAME,
+  PROMPT_INPUT_ACCESS_KEY,
+  PROMPT_INPUT_SECRET_KEY,
+  PROMPT_CHOICE_REGION
 };

--- a/bin/src/constants.js
+++ b/bin/src/constants.js
@@ -1,10 +1,20 @@
-import path from 'path';
-import userHome from 'user-home';
+const path = require('path');
+const userHome = require('user-home');
 
-export const SETTINGS_FILE = '.lambdasyncrc';
-export const AWS_USER_DIR = path.join(userHome, '.aws');
-export const AWS_CREDENTIALS_PATH = path.join(AWS_USER_DIR, 'credentials');
-export const AWS_CONFIG_PATH = path.join(AWS_USER_DIR, 'config');
-export const LAMBDASYNC_ROOT = path.join(__dirname);
-export const LAMBDASYNC_BIN = path.join(LAMBDASYNC_ROOT, '..', 'node_modules', '.bin');
-export const TARGET_ROOT = process.cwd();
+const SETTINGS_FILE = '.lambdasyncrc';
+const AWS_USER_DIR = path.join(userHome, '.aws');
+const AWS_CREDENTIALS_PATH = path.join(AWS_USER_DIR, 'credentials');
+const AWS_CONFIG_PATH = path.join(AWS_USER_DIR, 'config');
+const LAMBDASYNC_ROOT = path.join(__dirname);
+const LAMBDASYNC_BIN = path.join(LAMBDASYNC_ROOT, '..', '..', 'node_modules', '.bin');
+const TARGET_ROOT = process.cwd();
+
+module.exports = {
+  SETTINGS_FILE,
+  AWS_USER_DIR,
+  AWS_CREDENTIALS_PATH,
+  AWS_CONFIG_PATH,
+  LAMBDASYNC_ROOT,
+  LAMBDASYNC_BIN,
+  TARGET_ROOT
+};

--- a/bin/src/deploy.js
+++ b/bin/src/deploy.js
@@ -1,11 +1,36 @@
 const path = require('path');
+const inquirer = require('inquirer');
 const {promisedExec} = require('./util.js');
 const {getSettings} = require('./settings.js');
 const {LAMBDASYNC_BIN, TARGET_ROOT} = require('./constants.js');
+const aws = require('./aws.js');
 
 const targetOptions = {cwd: TARGET_ROOT};
 
 function deploy(settings) {
+  const AWS = aws(settings);
+  const lambda = new AWS.Lambda();
+  const doDeploy = deployFunction.bind(null, settings);
+
+  functionExists(lambda, settings.lambdaName)
+    .then(functionExists => {
+      // If function doesn't already exist just deploy it
+      if (!functionExists) {
+        return doDeploy();
+      }
+      // Otherwise let's ask to make sure
+      inquirer.prompt([{ type: 'confirm', name: 'confirm', message: 'Function already exists, overwrite?'}])
+        .then(function (result) {
+          if (result.confirm) {
+            doDeploy()
+          } else {
+            console.log('You answered no, aborting deploy');
+          }
+        });
+    });
+}
+
+function deployFunction(settings) {
   promisedExec(LAMBDASYNC_BIN + '/bestzip ./deploy.zip ./*', targetOptions)
     .then(stdout => promisedExec(
       'aws lambda update-function-code ' +
@@ -18,12 +43,29 @@ function deploy(settings) {
     .catch(err => {
       console.log('No config found, first run: lambdasync init');
       console.error(err);
-    })
+    });
 }
 
 function handleSuccess(stdout) {
   console.log('Successfully synced function', stdout);
   promisedExec(LAMBDASYNC_BIN + '/rimraf deploy.zip', targetOptions);
+}
+
+function functionExists(lambda, functionName) {
+  return new Promise((resolve, reject) => {
+    const params = {
+      FunctionName: functionName
+    };
+    lambda.getFunction(params, function(err, data) {
+      if (err) {
+        if (err.toString().includes('ResourceNotFoundException')) {
+          return resolve(false);
+        }
+        return reject(err);
+      }
+      return resolve(true);
+    });
+  });
 }
 
 module.exports = deploy;

--- a/bin/src/deploy.js
+++ b/bin/src/deploy.js
@@ -1,11 +1,11 @@
-import path from 'path';
-import {promisedExec} from './util.js';
-import {getSettings} from './settings.js';
-import {LAMBDASYNC_BIN, TARGET_ROOT} from './constants.js';
+const path = require('path');
+const {promisedExec} = require('./util.js');
+const {getSettings} = require('./settings.js');
+const {LAMBDASYNC_BIN, TARGET_ROOT} = require('./constants.js');
 
 const targetOptions = {cwd: TARGET_ROOT};
 
-export default function deploy(settings) {
+function deploy(settings) {
   promisedExec(LAMBDASYNC_BIN + '/bestzip ./deploy.zip ./*', targetOptions)
     .then(stdout => promisedExec(
       'aws lambda update-function-code ' +
@@ -25,3 +25,5 @@ function handleSuccess(stdout) {
   console.log('Successfully synced function', stdout);
   promisedExec(LAMBDASYNC_BIN + '/rimraf deploy.zip', targetOptions);
 }
+
+module.exports = deploy;

--- a/bin/src/file.js
+++ b/bin/src/file.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
+const fs = require('fs');
 
-export function readFile(path, transform = input => input) {
+function readFile(path, transform = input => input) {
   return new Promise((resolve, reject) => {
     fs.readFile(path, 'utf8', (err, data) => {
       if (err) {
@@ -15,7 +15,7 @@ export function readFile(path, transform = input => input) {
   });
 }
 
-export function writeFile(path, obj, transform = input => input.toString()) {
+function writeFile(path, obj, transform = input => input.toString()) {
   return new Promise((resolve, reject) => {
     let content = '';
     try {
@@ -32,3 +32,8 @@ export function writeFile(path, obj, transform = input => input.toString()) {
     });
   });
 }
+
+module.exports = {
+  readFile,
+  writeFile
+};

--- a/bin/src/index.js
+++ b/bin/src/index.js
@@ -1,8 +1,9 @@
-import minimist from 'minimist';
-import {getSettings} from './settings.js';
-import init from './init.js';
-import deploy from './deploy.js';
-import {version} from '../../package.json';
+#!/usr/bin/env node
+const minimist = require('minimist');
+const {getSettings} = require('./settings.js');
+const init = require('./init.js');
+const deploy = require('./deploy.js');
+const {version} = require('../../package.json');
 const command = minimist(process.argv.slice(2), {
   alias: {
     v: 'version'

--- a/bin/src/init.js
+++ b/bin/src/init.js
@@ -1,14 +1,14 @@
-import readline from 'readline';
-import {AWS_CREDENTIALS_PATH, AWS_CONFIG_PATH} from './constants.js';
-import {
+const readline = require('readline');
+const {AWS_CREDENTIALS_PATH, AWS_CONFIG_PATH} = require('./constants.js');
+const {
   settingsInput,
   settingsFields,
   putSettings,
   getAwsSettings,
   filterSettings
-} from './settings.js';
-import {readFile, writeFile} from './file.js';
-import ini from 'ini';
+} = require('./settings.js');
+const {readFile, writeFile} = require('./file.js');
+const ini = require('ini');
 
 
 const initRl = () => readline.createInterface({
@@ -18,7 +18,7 @@ const initRl = () => readline.createInterface({
 
 const rl = initRl();
 
-export default function init() {
+function init() {
   prompt({}, settingsInput, 0, settings => {
     console.log('Init complete, creating setting file:\n', JSON.stringify(filterSettings(settings, settingsFields), null, '  '));
     putSettings(settings);
@@ -79,3 +79,5 @@ function prompt(acc = {}, settings, index, cb) {
     cb(acc);
   }
 }
+
+module.exports = init;

--- a/bin/src/init.js
+++ b/bin/src/init.js
@@ -1,7 +1,6 @@
-const readline = require('readline');
+const inquirer = require('inquirer');
 const {AWS_CREDENTIALS_PATH, AWS_CONFIG_PATH} = require('./constants.js');
 const {
-  settingsInput,
   settingsFields,
   putSettings,
   getAwsSettings,
@@ -9,22 +8,27 @@ const {
 } = require('./settings.js');
 const {readFile, writeFile} = require('./file.js');
 const ini = require('ini');
-
-
-const initRl = () => readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-});
-
-const rl = initRl();
+const {
+  PROMPT_INPUT_PROFILE_NAME,
+  PROMPT_INPUT_FUNCTION_NAME,
+  PROMPT_INPUT_ACCESS_KEY,
+  PROMPT_INPUT_SECRET_KEY,
+  PROMPT_CHOICE_REGION
+} = require('./constants.js');
 
 function init() {
-  prompt({}, settingsInput, 0, settings => {
-    console.log('Init complete, creating setting file:\n', JSON.stringify(filterSettings(settings, settingsFields), null, '  '));
-    putSettings(settings);
-    persistAwsConfig(settings);
-    rl.close();
-  });
+  inquirer.prompt([
+    PROMPT_INPUT_PROFILE_NAME,
+    PROMPT_INPUT_FUNCTION_NAME,
+    PROMPT_INPUT_ACCESS_KEY,
+    PROMPT_INPUT_SECRET_KEY,
+    PROMPT_CHOICE_REGION
+  ])
+    .then(function (result) {
+      console.log('Init complete, creating setting file:\n', JSON.stringify(filterSettings(result, settingsFields), null, '  '));
+      putSettings(result);
+      persistAwsConfig(result);
+    });
 }
 
 function persistAwsConfig(conf) {
@@ -67,17 +71,6 @@ function persistAwsConfig(conf) {
         persistConfig();
       }
     });
-}
-
-function prompt(acc = {}, settings, index, cb) {
-  if (settings[index]) {
-    rl.question(settings[index] + ': ', answer => {
-      acc[settings[index]] = answer;
-      prompt(acc, settings, index + 1, cb);
-    });
-  } else {
-    cb(acc);
-  }
 }
 
 module.exports = init;

--- a/bin/src/settings.js
+++ b/bin/src/settings.js
@@ -1,12 +1,11 @@
-import path from 'path';
-import readline from 'readline';
-import ini from 'ini';
-import {SETTINGS_FILE, AWS_CREDENTIALS_PATH, AWS_CONFIG_PATH} from './constants.js';
-import {readFile, writeFile} from './file.js';
-import {jsonStringify} from './transform.js';
+const path = require('path');
+const ini = require('ini');
+const {SETTINGS_FILE, AWS_CREDENTIALS_PATH, AWS_CONFIG_PATH} = require('./constants.js');
+const {readFile, writeFile} = require('./file.js');
+const {jsonStringify} = require('./transform.js');
 
 
-export const settingsInput = [
+const settingsInput = [
   'profileName', // Name of local aws-cli profile, default lambdasync
   'lambdaName', // Name of lambda function on AWS
   'accessKey', // AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
@@ -14,7 +13,7 @@ export const settingsInput = [
   'region' // us-east-1
 ];
 
-export const settingsFields = [
+const settingsFields = [
   'profileName',
   'lambdaName',
   'region'
@@ -22,18 +21,18 @@ export const settingsFields = [
 
 const settingsPath = path.join(process.cwd(), SETTINGS_FILE);
 
-export function getSettings() {
+function getSettings() {
   return readFile(settingsPath, JSON.parse);
 }
 
-export function putSettings(settings) {
+function putSettings(settings) {
   return writeFile(
     settingsPath,
     filterSettings(settings, settingsFields),
     jsonStringify);
 }
 
-export function getAwsSettings() {
+function getAwsSettings() {
   return Promise.all([
     readFile(AWS_CREDENTIALS_PATH, ini.parse),
     readFile(AWS_CONFIG_PATH, ini.parse)
@@ -41,8 +40,17 @@ export function getAwsSettings() {
 }
 
 
-export function filterSettings(obj, fields) {
+function filterSettings(obj, fields) {
   return Object.keys(obj)
     .filter(key => fields.indexOf(key) !== -1)
     .reduce((res, key) => (res[key] = obj[key], res), {});
 }
+
+module.exports = {
+  settingsInput,
+  settingsFields,
+  getSettings,
+  putSettings,
+  getAwsSettings,
+  filterSettings
+};

--- a/bin/src/settings.js
+++ b/bin/src/settings.js
@@ -16,6 +16,8 @@ const settingsInput = [
 const settingsFields = [
   'profileName',
   'lambdaName',
+  'lambdaArn',
+  'lambdaRole',
   'region'
 ];
 
@@ -30,6 +32,21 @@ function putSettings(settings) {
     settingsPath,
     filterSettings(settings, settingsFields),
     jsonStringify);
+}
+
+function updateSettings(newFields) {
+  console.log('\n\n\n');
+  console.log('updateSettings', newFields);
+  console.log('\n\n\n');
+  return getSettings()
+    .then(settings => {
+      console.log('\n\n\n');
+      console.log('updateSettings settings', settings);
+      console.log('\n\n\n');
+      console.log('updateSettings merged settings', Object.assign({}, settings, newFields));
+      console.log('\n\n\n');
+      return putSettings(Object.assign({}, settings, newFields));
+    });
 }
 
 function getAwsSettings() {
@@ -51,6 +68,7 @@ module.exports = {
   settingsFields,
   getSettings,
   putSettings,
+  updateSettings,
   getAwsSettings,
   filterSettings
 };

--- a/bin/src/transform.js
+++ b/bin/src/transform.js
@@ -1,3 +1,7 @@
-export function jsonStringify(obj) {
+function jsonStringify(obj) {
   return JSON.stringify(obj, null, '  ');
 }
+
+module.exports = {
+  jsonStringify
+};

--- a/bin/src/util.js
+++ b/bin/src/util.js
@@ -1,6 +1,6 @@
-import cp from 'child_process';
+const cp = require('child_process');
 
-export function promisedExec(command, options) {
+function promisedExec(command, options) {
   return new Promise((resolve, reject) => {
     cp.exec(command, options = {}, (err, stdout, stderr) => {
       if (err) {
@@ -11,3 +11,7 @@ export function promisedExec(command, options) {
     });
   });
 }
+
+module.exports = {
+  promisedExec
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "watch": "npm-watch"
   },
   "bin": {
-    "lambdasync": "bin/lambdasync"
+    "lambdasync": "bin/src/index.js"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/fanderzon/lambdasync#readme",
   "dependencies": {
+    "aws-sdk": "2.4.13",
     "bestzip": "1.1.3",
     "ini": "1.3.4",
     "minimist": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "aws-sdk": "2.4.13",
     "bestzip": "1.1.3",
     "ini": "1.3.4",
+    "inquirer": "1.1.2",
     "minimist": "1.2.0",
     "rimraf": "2.5.4",
     "user-home": "2.0.0"


### PR DESCRIPTION
- Buildstep and rollup removed
- npm bin is now linked directly to `bin/src/index.js`
- Added the aws-sdk instead of using the aws cli
- Added support for creating the lambda function if it doesn't exist
- inquirer has been added to the project for nicer user prompts
