### PR TITLE
Fixed bug where `new` command would write lambdasync.json into the current working directory

### DIFF
--- a/bin/src/settings.js
+++ b/bin/src/settings.js
@@ -29,16 +29,14 @@ const settingsFields = [
   'apiGatewayDeploymentId'
 ];
 
-const settingsPath = path.join(process.cwd(), SETTINGS_FILE);
-
 function getSettings() {
-  return readFile(settingsPath, JSON.parse)
+  return readFile(path.join(process.cwd(), SETTINGS_FILE), JSON.parse)
     .catch(() => ({}));
 }
 
 function putSettings(settings) {
   return writeFile(
-    settingsPath,
+    path.join(process.cwd(), SETTINGS_FILE),
     filterSettings(settings, settingsFields),
     jsonStringify);
 }


### PR DESCRIPTION
Make settings.js always run process.cwd() instead of a cached variable (so that if we use process.chdir, it will apply)