### PR TITLE
lambdasync devserver

### DIFF
--- a/bin/src/devserver/express-compat.js
+++ b/bin/src/devserver/express-compat.js
@@ -1,0 +1,97 @@
+const RESOURCE_PATH = '/{proxy+}';
+const REQUEST_ID = 'cb8b2c6b-cp7f-11e6-921a-0f16afc9bdc3';
+
+function lambda(lambdasyncMeta) {
+  return {
+    callbackToExpressResponse(res, err, success) {
+      return proxyResponseToExpressResponse(res, err || success);
+    },
+  };
+};
+
+function express(lambdasyncMeta) {
+  return {
+    requestToLambdaEvent(req) {
+      return {
+        resource: RESOURCE_PATH,
+        path: req.originalUrl,
+        httpMethod: req.method,
+        headers: req.headers,
+        queryStringParameters: req.query,
+        pathParameters: {
+          proxy: 'api'
+        },
+        stageVariables: {}, // TODO: Add as CLI params for dev server
+        requestContext: {
+          accountId: lambdasyncMeta.accountId,
+          resourceId: lambdasyncMeta.apiGatewayResourceId,
+          stage: 'prod',
+          requestId: REQUEST_ID,
+          identity: {
+            cognitoIdentityPoolId: null,
+            accountId: null,
+            cognitoIdentityId: null,
+            caller: null,
+            apiKey: null,
+            sourceIp: ipFromReq(req),
+            accessKey: null,
+            cognitoAuthenticationType: null,
+            cognitoAuthenticationProvider: null,
+            userArn: null,
+            userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36",
+            user: null
+          },
+          resourcePath: RESOURCE_PATH,
+          httpMethod: req.method,
+          apiId: lambdasyncMeta.apiGatewayId
+        },
+        body: req.body,
+        isBase64Encoded: false,
+      };
+    },
+    responseToContext(res) {
+      var _callbackWaitsForEmptyEventLoop = true;
+
+      return {
+        get callbackWaitsForEmptyEventLoop() { return _callbackWaitsForEmptyEventLoop; },
+        set callbackWaitsForEmptyEventLoop(value) { _callbackWaitsForEmptyEventLoop = value; },
+        done: proxyResponseToExpressResponse.bind(null, res),
+        succeed: proxyResponseToExpressResponse.bind(null, res),
+        fail: proxyResponseToExpressResponse.bind(null, res),
+        logGroupName: '',
+        logStreamName: '',
+        functionName: lambdasyncMeta.lambdaName,
+        memoryLimitInMB: '128',
+        functionVersion: '$LATEST',
+        getRemainingTimeInMillis: function() {},
+        invokeid: '6914b06p-v26a-11m6-9bae-9b185520a60a',
+        awsRequestId: REQUEST_ID,
+        invokedFunctionArn: lambdasyncMeta.lambdaArn,
+      };
+    }
+  };
+}
+
+function ipFromReq(req) {
+  return req.headers['x-forwarded-for'] || req.connection.remoteAddress ||
+     req.socket.remoteAddress || req.connection.socket.remoteAddress;
+}
+
+function proxyResponseToExpressResponse(expressRes, proxyResponse) {
+  const {statusCode, headers, body} = proxyResponse;
+
+  if (headers) {
+    Object.keys(headers).forEach(key => expressRes.setHeader(key, headers[key]));
+  }
+
+  expressRes
+    .status(parseInt(statusCode, 10))
+    .send(body);
+}
+
+module.exports = function lambdaCompatFactory(lambdasyncMeta) {
+  return {
+    lambda: lambda(lambdasyncMeta),
+    express: express(lambdasyncMeta)
+  }
+};

--- a/bin/src/devserver/index.js
+++ b/bin/src/devserver/index.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const express = require('express');
+const app = express();
+
+const expressCompat = require('./express-compat');
+const lambdaHandler = require(path.join(process.cwd(), 'index.js')).handler;
+
+function start(settings) {
+  const compat = expressCompat(settings);
+
+  function proxyHandler(req, res) {
+    // Create event, context and callback params for the Lambda handler
+    const event = compat.express.requestToLambdaEvent(req);
+    const context = compat.express.responseToContext(res);
+    const callback = compat.lambda.callbackToExpressResponse.bind(null, res);
+
+    // Set response headers that makes sense for a dev server
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+
+    return lambdaHandler(event, context, callback);
+  }
+
+  app.get('/favicon*', (req, res) => {
+    res.sendFile(__dirname + '/favicon.ico');
+  });
+
+  app.get('/*', proxyHandler);
+
+  app.listen(3003, function() {
+    console.log('running server on port 3003');
+  });
+}
+
+module.exports = start;

--- a/bin/src/index.js
+++ b/bin/src/index.js
@@ -12,6 +12,7 @@ const {callApi} = require('./call-api.js');
 const {makeLambdaRole} = require('./iam.js');
 const scaffold = require('./scaffold.js');
 const {config, variable} = require('./config.js');
+const devServer = require('./devserver');
 
 const command = minimist(process.argv.slice(2), {
   alias: {
@@ -23,6 +24,11 @@ const command = minimist(process.argv.slice(2), {
 function handleCommand(command) {
   if (command.call) {
     return callApi(command);
+  }
+
+  if (command._[0] === 'devserver') {
+    return getSettings()
+      .then(settings => devServer(settings, command._.slice(1)));
   }
 
   if (command._[0] === 'config') {

--- a/bin/template/index.js
+++ b/bin/template/index.js
@@ -1,6 +1,10 @@
 exports.handler = (event, context, callback) => {
-  callback(null, {
+  context.fail({
     statusCode: 200,
-    message: 'Everything is awesome'
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify('Everything is awesome')
   });
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "aws-sdk": "2.7.8",
     "bestzip": "1.1.3",
     "copy-paste": "1.3.0",
+    "express": "4.14.0",
     "ini": "1.3.4",
     "inquirer": "1.1.2",
     "marked": "0.3.6",


### PR DESCRIPTION
Adds a `lambdasync devserver` command that spins up an express server om port 3003 to serve the users index.handler.

The res and req objects from express are converted to event and context objects to pass to the lambda function.

The return object (that must be one compatible with Lambda's procx functions) from the Lambda function's callback, `context.done`, `context.fail` or `context.success` will be passed to `res.send` in express.