### PR TITLE
Devserver all http methods

### DIFF
--- a/bin/src/devserver/express-compat.js
+++ b/bin/src/devserver/express-compat.js
@@ -45,7 +45,7 @@ function express(lambdasyncMeta) {
           httpMethod: req.method,
           apiId: lambdasyncMeta.apiGatewayId
         },
-        body: req.body,
+        body: stringifyBody(req.body),
         isBase64Encoded: false,
       };
     },
@@ -87,6 +87,17 @@ function proxyResponseToExpressResponse(expressRes, proxyResponse) {
   expressRes
     .status(parseInt(statusCode, 10))
     .send(body);
+}
+
+function stringifyBody(subject) {
+  try {
+    if (JSON.stringify(subject) === '{}') {
+      return null;
+    }
+    return JSON.stringify(subject);
+  } catch(err) {
+    return null;
+  }
 }
 
 module.exports = function lambdaCompatFactory(lambdasyncMeta) {

--- a/bin/src/devserver/index.js
+++ b/bin/src/devserver/index.js
@@ -1,8 +1,13 @@
 const path = require('path');
 const express = require('express');
+const bodyParser = require('body-parser');
+const cors = require('cors');
 const app = express();
 
 const expressCompat = require('./express-compat');
+app.use(cors());
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
 
 function start(settings) {
   const lambdaHandler = require(path.join(process.cwd(), 'index.js')).handler;
@@ -26,7 +31,7 @@ function start(settings) {
     res.sendFile(__dirname + '/favicon.ico');
   });
 
-  app.get('/*', proxyHandler);
+  app.all('*', proxyHandler);
 
   app.listen(3003, function() {
     console.log('running server on port 3003');

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "dependencies": {
     "aws-sdk": "2.7.8",
     "bestzip": "1.1.3",
+    "body-parser": "1.15.2",
     "copy-paste": "1.3.0",
+    "cors": "2.8.1",
     "cross-spawn": "5.0.1",
     "express": "4.14.0",
     "ini": "1.3.4",


### PR DESCRIPTION
This PR makes the devserver listen to all http methods, because I, like an idiot I only tested it with GET earlier.

It also stringifies the Lambda event body in the compatibility layer.