### PR TITLE
Fix for persisting AWS credentials when no ~/.aws directory exists

### DIFF
--- a/bin/src/file.js
+++ b/bin/src/file.js
@@ -1,3 +1,4 @@
+'use strict';
 const fs = require('fs');
 
 function readFile(path, transform = input => input) {

--- a/bin/src/file.js
+++ b/bin/src/file.js
@@ -1,5 +1,7 @@
 'use strict';
 const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
 
 function readFile(path, transform = input => input) {
   return new Promise((resolve, reject) => {
@@ -16,7 +18,7 @@ function readFile(path, transform = input => input) {
   });
 }
 
-function writeFile(path, obj, transform = input => input.toString()) {
+function writeFile(filePath, obj, transform = input => input.toString()) {
   return new Promise((resolve, reject) => {
     let content = '';
     try {
@@ -25,11 +27,14 @@ function writeFile(path, obj, transform = input => input.toString()) {
       return reject(err);
     }
 
-    fs.writeFile(path, content, 'utf8', err => {
-      if (err) {
-        return reject(err);
-      }
-      return resolve(content);
+    // Make sure the path that we want to write to exists
+    mkdirp(path.dirname(filePath), () => {
+      fs.writeFile(filePath, content, 'utf8', err => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(content);
+      });
     });
   });
 }

--- a/bin/src/file.test.js
+++ b/bin/src/file.test.js
@@ -1,0 +1,29 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
+
+const {readFile, writeFile} = require('./file');
+
+const TEST_DIR = path.join(process.cwd(), 'file-module-tests');
+const TEST_FILE_EXISTING = path.join(TEST_DIR, 'i-am-here.txt');
+const TEST_FILE_CREATE = path.join(TEST_DIR, 'create-me.txt');
+
+
+beforeEach(() => {
+  fs.mkdirSync(TEST_DIR);
+  fs.writeFile(TEST_FILE_EXISTING, '1');
+});
+
+afterEach(done => {
+  rimraf(TEST_DIR, done);
+});
+
+describe('file', () => {
+  describe('readFile', () => {
+    it('expect reading missing file to fail', () => {
+      readFile(TEST_FILE_CREATE)
+        .catch(e => expect(e).toBeTruthY());
+    });
+  });
+});

--- a/bin/src/file.test.js
+++ b/bin/src/file.test.js
@@ -6,6 +6,7 @@ const rimraf = require('rimraf');
 const {readFile, writeFile} = require('./file');
 
 const TEST_DIR = path.join(process.cwd(), 'file-module-tests');
+const MISSING_DIR = path.join(process.cwd(), 'make-believe');
 const TEST_FILE_EXISTING = path.join(TEST_DIR, 'i-am-here.txt');
 const TEST_FILE_CREATE = path.join(TEST_DIR, 'create-me.txt');
 
@@ -23,7 +24,40 @@ describe('file', () => {
   describe('readFile', () => {
     it('expect reading missing file to fail', () => {
       readFile(TEST_FILE_CREATE)
-        .catch(e => expect(e).toBeTruthY());
+        .catch(err => expect(err).toBeTruthy());
+    });
+    it('expect reading existing file to work', () => {
+      readFile(TEST_FILE_EXISTING)
+        .then(res => expect(res).toBe('1'));
+    });
+    it('expect transforms to be applied', () => {
+      readFile(TEST_FILE_EXISTING, Number)
+        .then(res => expect(res).toBe(1));
+    });
+    it('expect failed transforms to reject', () => {
+      readFile(TEST_FILE_EXISTING, content => JSON.parse('{'+content))
+        .catch(err => expect(err).toBeTruthy());
+    });
+  });
+  describe('writeFile', () => {
+    const Ash = {klaatu: 'verata', neck: 'tie'};
+    it('expect writing file to succeed', () => {
+      writeFile(TEST_FILE_CREATE, Ash)
+        .then(res => expect(res).toBeTruthy());
+    });
+    it('expect transforms to be applied', () => {
+      writeFile(TEST_FILE_CREATE, Ash, JSON.stringify)
+        .then(res => expect(JSON.parse(res)).toEqual(Ash));
+    });
+    it('expect writing file to missing directory to fail', () => {
+      writeFile(path.join(MISSING_DIR, 'a-file.json'), Ash)
+        .catch(err => expect(err).toBeTruthy());
+    });
+    it('expect failed transforms to reject', () => {
+      const Williams = Object.assign({}, Ash);
+      Williams.Williams = Williams;
+      writeFile(TEST_FILE_CREATE, undefined, JSON.stringify)
+        .catch(err => expect(err).toBeTruthy());
     });
   });
 });

--- a/bin/src/file.test.js
+++ b/bin/src/file.test.js
@@ -17,7 +17,8 @@ beforeEach(() => {
 });
 
 afterEach(done => {
-  rimraf(TEST_DIR, done);
+  rimraf(TEST_DIR, () => rimraf(MISSING_DIR, done));
+
 });
 
 describe('file', () => {
@@ -49,9 +50,9 @@ describe('file', () => {
       writeFile(TEST_FILE_CREATE, Ash, JSON.stringify)
         .then(res => expect(JSON.parse(res)).toEqual(Ash));
     });
-    it('expect writing file to missing directory to fail', () => {
-      writeFile(path.join(MISSING_DIR, 'a-file.json'), Ash)
-        .catch(err => expect(err).toBeTruthy());
+    it('expect writing file to missing directory to succeed', () => {
+      writeFile(path.join(MISSING_DIR, 'a-file.json'), Ash, JSON.stringify)
+        .then(res => expect(JSON.parse(res)).toEqual(Ash));
     });
     it('expect failed transforms to reject', () => {
       const Williams = Object.assign({}, Ash);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "marked": "0.3.6",
     "marked-terminal": "1.6.1",
     "minimist": "1.2.0",
+    "mkdirp": "0.5.1",
     "ncp": "2.0.0",
     "rimraf": "2.5.4",
     "user-home": "2.0.0",


### PR DESCRIPTION
This PR modifies the `writeFile` function of the file module to create directories that you are trying to write to if they do not already exists.

Also added are unit tests to verify this behaviour.