### PR TITLE
Fix for new execution roles not being created because of an unhandled reject

### DIFF
--- a/bin/src/iam.js
+++ b/bin/src/iam.js
@@ -54,7 +54,8 @@ function checkForExistingRoles(settings) {
     .then(res => updateSettings({
       lambdaPolicy: res.Policy.Arn
     }))
-    .then(getSettings);
+    .then(getSettings)
+    .catch(() => settings);
 }
 
 function attachPolicy(settings) {

--- a/bin/src/init.js
+++ b/bin/src/init.js
@@ -23,7 +23,7 @@ const {
 function init() {
   return getSettings()
     .then(settings => {
-      if (settings.profileName) {
+      if (settings.lambdaName && settings.profileName && settings.accountId) {
         console.log(markdown({
           templatePath: 'markdown/init-twice.md'
         }));


### PR DESCRIPTION
This PR fixes #15 by properly catching the promise rejection