### PR TITLE
Better error messages when running commands before deploy

### DIFF
--- a/bin/src/config.js
+++ b/bin/src/config.js
@@ -160,7 +160,9 @@ function variable(settings, operation, args) {
         }
       }
     })
-    .catch(handleGenericFailure);
+    .catch(() => console.log(markdown({
+      templatePath: 'markdown/secret-with-no-function.md'
+    })));
 }
 
 function makeSecretMarkdown(list, heading, label) {

--- a/bin/src/deploy.js
+++ b/bin/src/deploy.js
@@ -2,7 +2,13 @@ const fs = require('fs');
 const path = require('path');
 const inquirer = require('inquirer');
 const {description} = require('../../package.json');
-const {promisedExec, stripLambdaVersion, markdown, markdownProperty} = require('./util');
+const {
+  promisedExec,
+  stripLambdaVersion,
+  markdown,
+  markdownProperty,
+  functionExists
+} = require('./util');
 const {updateSettings} = require('./settings');
 const {
   LAMBDASYNC_BIN,
@@ -21,7 +27,7 @@ function deploy(deploySettings) {
   const AWS = aws(settings);
   lambda = new AWS.Lambda();
 
-  return functionExists(settings.lambdaName)
+  return functionExists(lambda, settings.lambdaName)
     .then(functionExists => {
       // If function doesn't already exist, or if it was already deployed
       // by lambdasync lets just deploy it
@@ -72,23 +78,6 @@ function handleSuccess(result) {
       }));
       return settings;
     });
-}
-
-function functionExists(functionName) {
-  return new Promise((resolve, reject) => {
-    const params = {
-      FunctionName: functionName
-    };
-    lambda.getFunction(params, err => {
-      if (err) {
-        if (err.toString().includes('ResourceNotFoundException')) {
-          return resolve(false);
-        }
-        return reject(err);
-      }
-      return resolve(true);
-    });
-  });
 }
 
 function zip() {

--- a/bin/src/markdown/logs-with-no-function.md
+++ b/bin/src/markdown/logs-with-no-function.md
@@ -1,0 +1,5 @@
+# function not deployed
+=====================================
+You need to deploy your function before you can get logs for it.
+
+Deploy your function by running `lambdasync` first.

--- a/bin/src/markdown/secret-with-no-function.md
+++ b/bin/src/markdown/secret-with-no-function.md
@@ -1,0 +1,5 @@
+# function not deployed
+=====================================
+You need to deploy your function before you can add secrets to it.
+
+Deploy your function by running `lambdasync` first.

--- a/bin/src/util.js
+++ b/bin/src/util.js
@@ -194,6 +194,23 @@ const chainData = fn =>
 
 const startWith = data => Promise.resolve(data);
 
+function functionExists(api, functionName) {
+  return new Promise((resolve, reject) => {
+    const params = {
+      FunctionName: functionName
+    };
+    api.getFunction(params, err => {
+      if (err) {
+        if (err.toString().includes('ResourceNotFoundException')) {
+          return resolve(false);
+        }
+        return reject(err);
+      }
+      return resolve(true);
+    });
+  });
+}
+
 exports = module.exports = {};
 exports.promisedExec = promisedExec;
 exports.handleGenericFailure = handleGenericFailure;
@@ -213,6 +230,7 @@ exports.logger = logger;
 exports.logMessage = logMessage;
 exports.formatTimestamp = formatTimestamp;
 exports.isDate = isDate;
+exports.functionExists = functionExists;
 
 if (process.env.NODE_ENV === 'test') {
   exports.getProductionDeps = getProductionDeps;


### PR DESCRIPTION
Running `lambdasync logs` or `lambdasync secret` before you have deployed a function will not work, as they both need a live Lambda function to work with.

Lambdasync would previously give very unhelpful errors, this PR adds a simple message telling the user that the function needs to be deployed before you can get logs or add secrets.

This PR fixes #15 #14 