### PR TITLE
Configuration support for `entry`, `ignore` and `include`

### DIFF
--- a/bin/src/util.js
+++ b/bin/src/util.js
@@ -204,6 +204,25 @@ function isDate(date) {
     (date.toString() && date.toString() !== 'Invalid Date');
 }
 
+function removeFileExtension(path = '') {
+  // Instead of setting rules for what a file extension is based on length and allowed chars
+  // Let's just specify which file endings we want to be able to remove
+  const extensionsToRemove = ['js'];
+  // Get position of last dot
+  const lastDotPosition = path.lastIndexOf('.');
+  // If none are found we can safely just return the original string
+  if (lastDotPosition === -1) {
+    return path;
+  }
+
+  // Get the file extension (right of the last dot)
+  const maybeExtension = path.substr(lastDotPosition + 1);
+  if (extensionsToRemove.indexOf(maybeExtension) !== -1) {
+    return path.substr(0, lastDotPosition);
+  }
+  return path;
+}
+
 exports = module.exports = {};
 exports.promisedExec = promisedExec;
 exports.handleGenericFailure = handleGenericFailure;
@@ -226,6 +245,7 @@ exports.copyPackageJson = copyPackageJson;
 exports.npmInstall = npmInstall;
 exports.hashPackageDependencies = hashPackageDependencies;
 exports.ignoreData = ignoreData;
+exports.removeFileExtension = removeFileExtension;
 
 if (process.env.NODE_ENV === 'test') {
   exports.isDate = isDate;

--- a/bin/src/util.test.js
+++ b/bin/src/util.test.js
@@ -21,7 +21,8 @@ const {
   formatTimestamp,
   delay,
   startWith,
-  isDate
+  isDate,
+  removeFileExtension
 } = require('./util');
 
 describe('util', () => {
@@ -330,6 +331,14 @@ lambdasync
       expect(isDate(42)).toBe(false);
       expect(isDate([])).toBe(false);
       expect(isDate({})).toBe(false);
+    });
+  });
+
+  describe('removeFileExtension', () => {
+    it('should remove known file extensions', () => {
+      expect(removeFileExtension('./hej/kom/och/hjalp/mig.js')).toBe('./hej/kom/och/hjalp/mig');
+      expect(removeFileExtension('lambdasync.com')).toBe('lambdasync.com');
+      expect(removeFileExtension('lambdasync')).toBe('lambdasync');
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1812,14 +1812,6 @@
             "os-shim": "0.1.3"
           }
         },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1828,6 +1820,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {


### PR DESCRIPTION
This PR adds support for a `"lambdasync"` section in the projects `package.json`, the fields supported are:


* `entry` - The path to the entry file (string - default is "index.js")
* `ignore` - Array of globs to not include in the deploy bundle, (i.e.  ["node_modules/**"])
* `include` - Array of globs to include in the deploy bundle, only files matching these globs will be included (i.e. ["dist/**"])