### PR TITLE
Custom lambdasync.json path

### DIFF
--- a/bin/src/index.js
+++ b/bin/src/index.js
@@ -5,7 +5,7 @@ const minimist = require('minimist');
 const chainData = require('chain-promise-data');
 
 const {version} = require('../../package.json');
-const {getSettings} = require('./settings');
+const {getSettings,setSettingsFile} = require('./settings');
 const maybeInit = require('./init');
 const deploy = require('./deploy');
 const {setupApiGateway, deployApi} = require('./gateway');
@@ -20,11 +20,17 @@ const {logs} = require('./logs');
 const command = minimist(process.argv.slice(2), {
   alias: {
     v: 'version',
-    c: 'call'
+    c: 'call',
+    sf: 'settings-file',
   }
 });
 
 function handleCommand(command) {
+  if (command.sf && typeof command.sf === 'string') {
+    console.log('Changing settingsfile to: ' + command.sf);
+    setSettingsFile(command.sf);
+  }
+
   if (command.call) {
     return callApi(command);
   }

--- a/bin/src/settings.js
+++ b/bin/src/settings.js
@@ -4,6 +4,7 @@ const ini = require('ini');
 const {SETTINGS_FILE, AWS_CREDENTIALS_PATH, AWS_CONFIG_PATH} = require('./constants');
 const {readFile, writeFile} = require('./file');
 const {jsonStringify} = require('./transform');
+const {makeAbsolutePath} = require('./util');
 
 const settingsInput = [
   'profileName', // Name of local aws-cli profile, default lambdasync
@@ -29,14 +30,16 @@ const settingsFields = [
   'apiGatewayDeploymentId'
 ];
 
+let settingsFile = path.join(process.cwd(), SETTINGS_FILE);
+
 function getSettings() {
-  return readFile(path.join(process.cwd(), SETTINGS_FILE), JSON.parse)
+  return readFile(settingsFile, JSON.parse)
     .catch(() => ({}));
 }
 
 function putSettings(settings) {
   return writeFile(
-    path.join(process.cwd(), SETTINGS_FILE),
+    settingsFile,
     filterSettings(settings, settingsFields),
     jsonStringify);
 }
@@ -67,6 +70,10 @@ function filterSettings(obj, fields) {
     }, {});
 }
 
+function setSettingsFile(settingsPath) {
+  settingsFile = makeAbsolutePath(settingsPath);
+}
+
 module.exports = {
   settingsInput,
   settingsFields,
@@ -74,5 +81,6 @@ module.exports = {
   putSettings,
   updateSettings,
   getAwsSettings,
-  filterSettings
+  filterSettings,
+  setSettingsFile,
 };

--- a/bin/src/util.js
+++ b/bin/src/util.js
@@ -200,7 +200,7 @@ function ignoreData() {
 }
 
 function isDate(date) {
-  return Object.prototype.toString.call(date) === '[object Date]' && 
+  return Object.prototype.toString.call(date) === '[object Date]' &&
     (date.toString() && date.toString() !== 'Invalid Date');
 }
 
@@ -221,6 +221,16 @@ function removeFileExtension(path = '') {
     return path.substr(0, lastDotPosition);
   }
   return path;
+}
+
+function makeAbsolutePath(inPath) {
+  // First find out if the path is absolute
+  if (path.isAbsolute(inPath)) {
+    return inPath;
+  }
+
+  // Otherwise build an absolute path from process.cwd()
+  return path.join(process.cwd(), inPath);
 }
 
 exports = module.exports = {};
@@ -246,6 +256,7 @@ exports.npmInstall = npmInstall;
 exports.hashPackageDependencies = hashPackageDependencies;
 exports.ignoreData = ignoreData;
 exports.removeFileExtension = removeFileExtension;
+exports.makeAbsolutePath = makeAbsolutePath;
 
 if (process.env.NODE_ENV === 'test') {
   exports.isDate = isDate;

--- a/bin/src/util.test.js
+++ b/bin/src/util.test.js
@@ -22,7 +22,8 @@ const {
   delay,
   startWith,
   isDate,
-  removeFileExtension
+  removeFileExtension,
+  makeAbsolutePath
 } = require('./util');
 
 describe('util', () => {
@@ -339,6 +340,17 @@ lambdasync
       expect(removeFileExtension('./hej/kom/och/hjalp/mig.js')).toBe('./hej/kom/och/hjalp/mig');
       expect(removeFileExtension('lambdasync.com')).toBe('lambdasync.com');
       expect(removeFileExtension('lambdasync')).toBe('lambdasync');
+    });
+  });
+
+  describe('makeAbsolutePath', () => {
+    const ABS_PATH = '/Users/lambdasync';
+    const REL_PATH = './bin/src/file.js';
+    it('should return absolute paths unchanged', () => {
+      expect(makeAbsolutePath(ABS_PATH)).toBe(ABS_PATH);
+    });
+    it('should add process.cwd() to relative paths', () => {
+      expect(makeAbsolutePath(REL_PATH)).toBe(path.join(process.cwd(), REL_PATH));
     });
   });
 });


### PR DESCRIPTION
This PR adds functionality to specify the path to the lambdasync.json metadata file to use for any lambdasync command by adding:

`--settings-file=lambdasync.private.json`
or the shorter alias
`--sf=lambdasync.dev.json`

to the command.