### PR TITLE
When AWS changed the format of the log event timestamps it broke the `lambdasync logs` function

### DIFF
--- a/bin/src/logs.js
+++ b/bin/src/logs.js
@@ -67,7 +67,7 @@ function fetchLogs({api, logGroupName, startTime}) {
 }
 
 function logEvent({timestamp, message}) {
-  const time = formatTimestamp(timestamp);
+  const time = formatTimestamp(new Date(timestamp));
   const requestId = chalk.yellow(getRequestIdFromMessage(message) || 'NO REQUESTID');
   let msg = `${time} ${requestId} - ${message}`;
 


### PR DESCRIPTION
This PR fixes it by converting the integer timestamp to a Date object before passing it to `util.formatTimestamp`