### PR TITLE
Devserver --inspect (and other node flags support)

### DIFF
--- a/bin/src/deploy.js
+++ b/bin/src/deploy.js
@@ -210,7 +210,7 @@ function matchesPatterns(path, patterns = []) {
   }
   return patterns.reduce((res, pattern) => {
     if (res) { return res; }
-    return minimatch(path, pattern);
+    return minimatch(path, pattern, { dot: true });
   }, false);
 }
 

--- a/bin/src/index.js
+++ b/bin/src/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 const path = require('path');
+const {execSync} = require('child_process');
 const minimist = require('minimist');
 const chainData = require('chain-promise-data');
 
@@ -14,8 +15,8 @@ const {callApi} = require('./call-api');
 const {makeLambdaRole} = require('./iam');
 const scaffold = require('./scaffold');
 const {config, variable} = require('./config');
-const devServer = require('./devserver');
 const {logs} = require('./logs');
+const {LAMBDASYNC_SRC} = require('./constants');
 
 const command = minimist(process.argv.slice(2), {
   alias: {
@@ -27,7 +28,6 @@ const command = minimist(process.argv.slice(2), {
 
 function handleCommand(command) {
   if (command.sf && typeof command.sf === 'string') {
-    console.log('Changing settingsfile to: ' + command.sf);
     setSettingsFile(command.sf);
   }
 
@@ -36,9 +36,7 @@ function handleCommand(command) {
   }
 
   if (command._[0] === 'devserver') {
-    const lambdaHandler = require(path.join(process.cwd(), 'index.js')).handler; // eslint-disable-line import/no-dynamic-require
-    return getSettings()
-      .then(settings => devServer(settings, lambdaHandler, command._.slice(1)));
+    return execSync(`node ${process.argv.slice(3).join(' ')} ${path.join(LAMBDASYNC_SRC, 'devserver', 'index.js')}`, {stdio:[0,1,2]});
   }
 
   if (command._[0] === 'logs') {


### PR DESCRIPTION
Previously the devserver was started through the `lambdasync` executable, because Lambdasync required it and ran it as part of it's own process.

This PR changes this behavior so that running `lambdasync devserver` now executes as a `node devserver/index.js` command through Node's `child_process.execSync`.

Any additional arguments are passed as flags when starting the devserver, so for example `lambdasync devserver --inspect` becomes `node --inspect devserver/index.js`.