### PR TITLE
Use path instead of originalUrl

### DIFF
--- a/bin/src/devserver/express-compat.js
+++ b/bin/src/devserver/express-compat.js
@@ -14,7 +14,7 @@ function express(lambdasyncMeta) {
     requestToLambdaEvent(req) {
       return {
         resource: RESOURCE_PATH,
-        path: req.originalUrl,
+        path: req.path,
         httpMethod: req.method,
         headers: req.headers,
         queryStringParameters: req.query,


### PR DESCRIPTION
originalUrl contains the querystring, which will garble the path once it reaches the actual Express app.