### PR TITLE
Whitelist Node CLI options to be passed through when running the devserver

### DIFF
--- a/bin/src/index.js
+++ b/bin/src/index.js
@@ -37,14 +37,8 @@ function handleCommand(command) {
 
   if (command._[0] === 'devserver') {
     const nodeCliWhiteList = ['-r', '--inspect', '--inspect-brk', '--inspect-port', '--trace-sync-io', '--preserve-symlinks', '--icu-data-dir'];
-    function isWhitelisted(arg) {
-      return nodeCliWhiteList.reduce((acc, current) => {
-        if (arg.indexOf(current) === 0) {
-          return true;
-        }
-        return acc;
-      }, false);
-    }
+    const whiteListRe = new RegExp(`^(${nodeCliWhiteList.join('|')})(=|$)`);
+    const isWhitelisted = arg => whiteListRe.test(arg);
     return execSync(`node ${process.argv
       .slice(3)
       .filter(isWhitelisted)

--- a/bin/src/index.js
+++ b/bin/src/index.js
@@ -36,7 +36,20 @@ function handleCommand(command) {
   }
 
   if (command._[0] === 'devserver') {
-    return execSync(`node ${process.argv.slice(3).join(' ')} ${path.join(LAMBDASYNC_SRC, 'devserver', 'index.js')}`, {stdio:[0,1,2]});
+    const nodeCliWhiteList = ['-r', '--inspect', '--inspect-brk', '--inspect-port', '--trace-sync-io', '--preserve-symlinks', '--icu-data-dir'];
+    function isWhitelisted(arg) {
+      return nodeCliWhiteList.reduce((acc, current) => {
+        if (arg.indexOf(current) === 0) {
+          return true;
+        }
+        return acc;
+      }, false);
+    }
+    return execSync(`node ${process.argv
+      .slice(3)
+      .filter(isWhitelisted)
+      .join(' ')
+    } ${path.join(LAMBDASYNC_SRC, 'devserver', 'index.js')}`, {stdio:[0,1,2]});
   }
 
   if (command._[0] === 'logs') {


### PR DESCRIPTION
This PR adds a whitelist of the Node CLI options that could be used runtime by the user when starting the devserver.