### PR TITLE
Fixed absolute path bug in custom entry path behavior

### DIFF
--- a/bin/src/deploy.js
+++ b/bin/src/deploy.js
@@ -20,7 +20,8 @@ const {
   hashPackageDependencies,
   awsPromise,
   removeFileExtension,
-  makeAbsolutePath
+  makeAbsolutePath,
+  removeCurrentPath
 } = require('./util');
 const {updateSettings} = require('./settings');
 const {
@@ -133,8 +134,7 @@ function shouldIncludeNodeModules(packageJson) {
   const { ignore, include } = packageJson.lambdasync || {};
   const nodeModulesPath = 'node_modules/module';
   const ignoreMatch = ignore ? matchesPatterns(nodeModulesPath, ignore) : false;
-  const includeMatch = include ? matchesPatterns(nodeModulesPath, include) : true;
-  return (!ignoreMatch && includeMatch);
+  return !ignoreMatch;
 }
 
 function ensureDependencies({ packageJson }) {
@@ -238,7 +238,7 @@ function zip() {
 
 function getHandlerPath(entryConfig) {
   return `${entryConfig ?
-    removeFileExtension(makeAbsolutePath(entryConfig)) :
+    removeFileExtension(removeCurrentPath(makeAbsolutePath(entryConfig))) :
     'index'
   }.handler`;
 }

--- a/bin/src/util.js
+++ b/bin/src/util.js
@@ -15,9 +15,9 @@ marked.setOptions({
 });
 
 // Executes a CLI command and returns a promise
-function promisedExec(command, options) { // eslint-disable-line no-unused-vars
+function promisedExec(command, options = {}) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => {
-    cp.exec(command, options = {}, (err, stdout) => {
+    cp.exec(command, options, (err, stdout) => {
       if (err) {
         return reject(err);
       }
@@ -204,6 +204,11 @@ function isDate(date) {
     (date.toString() && date.toString() !== 'Invalid Date');
 }
 
+function removeCurrentPath(path = '') {
+  const pathToRemove = `${process.cwd()}/`;
+  return path.replace(pathToRemove, '');
+}
+
 function removeFileExtension(path = '') {
   // Instead of setting rules for what a file extension is based on length and allowed chars
   // Let's just specify which file endings we want to be able to remove
@@ -257,6 +262,7 @@ exports.hashPackageDependencies = hashPackageDependencies;
 exports.ignoreData = ignoreData;
 exports.removeFileExtension = removeFileExtension;
 exports.makeAbsolutePath = makeAbsolutePath;
+exports.removeCurrentPath = removeCurrentPath;
 
 if (process.env.NODE_ENV === 'test') {
   exports.isDate = isDate;


### PR DESCRIPTION
This PR fixes an (embarrassing) bug where during a refactor I managed to make the custom entry path absolute when writing it to the lambda config, which would cause Lambda to not find your entry file.